### PR TITLE
ログインロジックの修正

### DIFF
--- a/laravel/app/Domains/ServiceUser/Controller/GenerateAuthTokenAction.php
+++ b/laravel/app/Domains/ServiceUser/Controller/GenerateAuthTokenAction.php
@@ -30,7 +30,7 @@ class GenerateAuthTokenAction extends Controller
     {
         $command = new TokenCreateCommand(
             $request->email,
-            str_pad((string)random_int(0, 999999), 6, '0', STR_PAD_LEFT),
+            bin2hex(random_bytes(4))
         );
 
         $this->interactor->handle($command);

--- a/laravel/app/Domains/ServiceUser/Controller/LoginAction.php
+++ b/laravel/app/Domains/ServiceUser/Controller/LoginAction.php
@@ -57,6 +57,11 @@ class LoginAction extends Controller
 
         Auth::guard('service_users')->login($user);
 
+        // トークンを無効化
+        $user->onetime_token = null;
+        $user->onetime_expiration = null;
+        $user->save();
+
         $this->addOperationLog(OperationLog::OPERATION_TYPE_LOGIN, "ユーザーID", User::AuthId());
 
         $request->session()->regenerate();

--- a/laravel/app/Domains/ServiceUser/Usecase/Command/TokenCreateCommand.php
+++ b/laravel/app/Domains/ServiceUser/Usecase/Command/TokenCreateCommand.php
@@ -18,9 +18,9 @@ class TokenCreateCommand
     }
 
     /**
-     * @return int
+     * @return string
      */
-    public function getEmail()
+    public function getEmail(): string
     {
         return $this->email;
     }


### PR DESCRIPTION
- ランダムの6桁の数値をワンタイムトークンにしていたけどランダムな文字列に変更
- ログイン完了後にワンタイムトークンをDBから削除して使い捨てにした
- ログイン試行回数が多いとロックする機能を追加