### PR TITLE
DBの肥大化を防ぐため自動で不要レコードを削除する機能の実装

### DIFF
--- a/frontend-user/index.html
+++ b/frontend-user/index.html
@@ -50,10 +50,10 @@
           : (d[l] = (f, ...n) => r.add(f) && u().then(() => d[l](f, ...n)));
       })({
         key: 'AIzaSyB41DRUbKWJHPxaFjMAwdrzWzbVKartNGg',
-        v: 'weekly',
+        v: 'weekly,beta',
         region: 'JP',
         language: 'ja',
-        libraries: 'places, marker'
+        libraries: 'places,marker'
         // Use the 'v' parameter to indicate the version to use (weekly, beta, alpha, etc.).
         // Add other bootstrap parameters as needed, using camel case.
       });

--- a/frontend-user/src/router/index.ts
+++ b/frontend-user/src/router/index.ts
@@ -207,20 +207,25 @@ router.beforeEach(async (to, from, next) => {
   }
   document.title = (to.meta.title ? to.meta.title + ' | ' : '') + 'Curry Addiction';
 
+  // リロード時やアプリ起動時にユーザー情報を取得
+  if (accountStore.isLoadingUserData) {
+    await accountStore.fetchUserData();
+  }
+
   // signupページへのダイレクトアクセス制限
   if (to.name === 'Signup' && !accountStore.state.isNewRegistration) {
     return next({ name: 'Welcome' });
+  }
+
+  // ログイン中にWelcomeページにアクセスしようとした場合、Homeにリダイレクト
+  if (to.name === 'Welcome' && accountStore.isAuthenticated) {
+    return next({ name: 'Home' });
   }
 
   // 認証が必要なページへのアクセス制限
   if (to.matched.some((record) => record.meta.requiresAuth)) {
     // リファラの設定
     commonStore.setOriginalRoute(from);
-
-    // リロード時ユーザー情報取得を待つ
-    if (accountStore.isLoadingUserData) {
-      await accountStore.fetchUserData();
-    }
 
     return accountStore.isAuthenticated ? next() : next({ name: 'Welcome' });
   }

--- a/frontend-user/src/views/molecules/HeaderNavigation.vue
+++ b/frontend-user/src/views/molecules/HeaderNavigation.vue
@@ -27,7 +27,7 @@ const navItems: NavItem[] = [
 ];
 
 const itemStyles = tv({
-  base: 'peer flex aspect-square w-8 items-center justify-center rounded-full transition-opacity duration-500 hover:bg-gray-100'
+  base: 'peer flex aspect-square w-8 items-center justify-center rounded-full transition-opacity duration-500 lg:hover:bg-gray-100'
 });
 </script>
 <template>

--- a/frontend-user/src/views/molecules/dropdown/NotificationDropDown.vue
+++ b/frontend-user/src/views/molecules/dropdown/NotificationDropDown.vue
@@ -57,7 +57,7 @@ onMounted(() => {
   <Menu class="relative flex items-center justify-center" as="div" v-slot="{ open }">
     <BottomTooltip :open text="お知らせ" position="bottom">
       <NotificationButton
-        class="peer relative flex h-8 w-8 items-center justify-center rounded-full transition-opacity duration-500 hover:bg-gray-100"
+        class="peer relative flex h-8 w-8 items-center justify-center rounded-full transition-opacity duration-500 lg:hover:bg-gray-100"
         @click="markAsRead"
       />
       <span

--- a/frontend-user/src/views/pages/Dashboard/Setting/Index.vue
+++ b/frontend-user/src/views/pages/Dashboard/Setting/Index.vue
@@ -186,6 +186,8 @@ async function doDelete(): Promise<void> {
     const response = await accountFormStore.deleteAccount(String(accountStore.state.uuid));
     if (response.status === 200) {
       closeModal();
+      accountStore.resetData();
+      window.alert('アカウントを削除しました。');
       router.push({ name: 'Welcome' });
       document.body.style.overflow = 'auto';
     } else {

--- a/laravel/app/Console/Commands/CleanupPendingServiceUsers.php
+++ b/laravel/app/Console/Commands/CleanupPendingServiceUsers.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\ServiceUser;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+
+class CleanupPendingServiceUsers extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:cleanup-pending-service-users';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Delete pending service users older than 24 hours';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $twentyFourHoursAgo = Carbon::now()->subDay();
+
+        $pendingServiceUsers = ServiceUser::where('status', ServiceUser::STATUS_PENDING)
+            ->where('created_at', '<', $twentyFourHoursAgo)
+            ->get();
+
+        $deletedCount = 0;
+        foreach ($pendingServiceUsers as $serviceUser) {
+            // サービス利用者に紐づくUserも削除する
+            if ($serviceUser->user) {
+                $serviceUser->user->forceDelete();
+            }
+            $serviceUser->forceDelete();
+            $deletedCount++;
+        }
+
+        $this->info("Deleted {$deletedCount} pending service users and their associated users older than 24 hours.");
+    }
+
+}

--- a/laravel/app/Console/Commands/HardDeleteOldPosts.php
+++ b/laravel/app/Console/Commands/HardDeleteOldPosts.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Post;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+
+class HardDeleteOldPosts extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:hard-delete-old-posts';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Hard delete posts that were soft deleted more than 30 days ago';
+
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $thirtyDaysAgo = Carbon::now()->subDays(30);
+
+        $deletedCount = Post::onlyTrashed()
+            ->where('deleted_at', '<', $thirtyDaysAgo)
+            ->forceDelete();
+
+        $this->info("Hard deleted {$deletedCount} posts that were soft deleted more than 30 days ago.");
+    }
+}

--- a/laravel/app/Console/Kernel.php
+++ b/laravel/app/Console/Kernel.php
@@ -12,7 +12,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule): void
     {
-        // $schedule->command('inspire')->hourly();
+        $schedule->command('app:hard-delete-old-posts')->daily()->timezone('Asia/Tokyo');
     }
 
     /**

--- a/laravel/app/Console/Kernel.php
+++ b/laravel/app/Console/Kernel.php
@@ -13,6 +13,7 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule): void
     {
         $schedule->command('app:hard-delete-old-posts')->daily()->timezone('Asia/Tokyo');
+        $schedule->command('app:cleanup-pending-service-users')->everyFiveSeconds()->timezone('Asia/Tokyo');
     }
 
     /**

--- a/laravel/app/Domains/ServiceUser/Usecase/DeleteInteractor.php
+++ b/laravel/app/Domains/ServiceUser/Usecase/DeleteInteractor.php
@@ -39,6 +39,7 @@ class DeleteInteractor
 
             // ServiceUserモデル削除
             $serviceUser->delete();
+            $serviceUser->update(['status' => ServiceUser::STATUS_DELETED]);
 
             DB::commit();
         } catch (\Exception $e) {
@@ -48,7 +49,7 @@ class DeleteInteractor
     }
 
     /**
-     * 同一メールアドレス登録できるようにunique制限を避けるためメールアドレスを更新する
+     * 次回同一メールアドレス登録できるようにunique制限を避けるためメールアドレスを更新する
      * ※ handle_name は更新しない
      *
      * @param ServiceUser $serviceUser

--- a/laravel/app/Models/ServiceUser.php
+++ b/laravel/app/Models/ServiceUser.php
@@ -51,11 +51,13 @@ class ServiceUser extends Authenticatable
     public const STATUS_DISABLED = 0;   // 利用不可
     public const STATUS_ENABLED = 1;    // 利用可
     public const STATUS_PENDING = 2;    // 仮登録
+    public const STATUS_DELETED = 99;   // 削除済み
 
     public const STATUSES = [
         self::STATUS_DISABLED => '使用不可',
         self::STATUS_ENABLED => '使用可',
         self::STATUS_PENDING => '仮登録',
+        self::STATUS_DELETED => '削除済み',
     ];
 
     protected $dates = [


### PR DESCRIPTION
## ごみ箱に入れてから30日経過した投稿の削除
- タスクスケジューラーを作成して日本時間の24時に毎日実行するように実装

##ステータスがpending（レコードには存在するがアカウント未登録）のユーザーは24時間経過で削除
- タスクスケジューラーを作成して日本時間の24時に毎日実行するように実装
- ServiceUserに紐づくUserも削除
- ServiceUser,UserともにSoftDeleteトレイトを使用しているため通常の`delete()`ではなく`forceDelete()`を使用

### タスクの実行
```
docker exec curry_addiction_php-fpm php artisan schedule:work
```
上記コマンドを実行する

# TODO
- 本番環境では`cron`を設定する必要がある